### PR TITLE
Upgrade compatibility and fix vulnerability

### DIFF
--- a/src/gui/N2Go_Gui.php
+++ b/src/gui/N2Go_Gui.php
@@ -88,10 +88,10 @@ class N2Go_Gui
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
             $this->save_option('n2go_formUniqueCode', $_POST['formUniqueCode']);
 
-            $widgetStyleConfig = json_decode(stripcslashes($_POST['widgetStyleConfig']));
-            if (isset($widgetStyleConfig)) {
+            if (isset($_POST['widgetStyleConfig'])) {
                 $this->save_option('n2go_widgetStyleConfig', $_POST['widgetStyleConfig']);
             }
+
             if (isset($_POST['resetValues'])) {
                 $this->disconnect();
             }

--- a/src/gui/N2Go_Gui.php
+++ b/src/gui/N2Go_Gui.php
@@ -136,8 +136,6 @@ class N2Go_Gui
         if (strlen($formUniqueCode) > 0 && !isset($forms[$formUniqueCode])) {
             $this->save_option('n2go_formUniqueCode', null);
             $formUniqueCode = null;
-        } else {
-            $form = $forms[$formUniqueCode];
         }
 
         require_once dirname(__FILE__) . '/adminView.php';

--- a/src/gui/N2Go_Gui.php
+++ b/src/gui/N2Go_Gui.php
@@ -295,7 +295,7 @@ class N2Go_Gui
      */
     function resetStyles()
     {
-        $style = $_POST['style'];
+        $style = file_get_contents(plugins_url('/lib/newsletter2go_default.json', __FILE__));
         $this->save_option('n2go_widgetStyleConfig', $style);
         echo true;
         wp_die();

--- a/src/gui/N2Go_Gui.php
+++ b/src/gui/N2Go_Gui.php
@@ -86,7 +86,7 @@ class N2Go_Gui
         }
 
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-            $this->save_option('n2go_formUniqueCode', $_POST['formUniqueCode']);
+            $this->save_option('n2go_formUniqueCode', htmlspecialchars($_POST['formUniqueCode']));
 
             if (isset($_POST['widgetStyleConfig'])) {
                 $this->save_option('n2go_widgetStyleConfig', $_POST['widgetStyleConfig']);

--- a/src/gui/lib/newsletter2go_default.json
+++ b/src/gui/lib/newsletter2go_default.json
@@ -1,0 +1,68 @@
+{
+    "form": {
+        "class": "",
+        "style": ""
+    },
+    "container": {
+        "type": "div",
+        "class": "",
+        "style": "width: 100%;"
+    },
+    "row": {
+        "type": "div",
+        "class": "",
+        "style": ""
+    },
+    "columnLeft": {
+        "type": "div",
+        "class": "",
+        "style": "width: 40%; padding: 10px 5px; display: inline-block;"
+    },
+    "columnRight": {
+        "type": "div",
+        "class": "",
+        "style": " width: 60%; display: inline-block;"
+    },
+    "checkbox": {
+        "type": "input",
+        "class": "",
+        "style": ""
+    },
+    "separator": {
+        "type": "br",
+        "class": "",
+        "style": ""
+    },
+    "input": {
+        "class": "",
+        "style": "padding: 5px 10px; border-radius: 2px; border: 1px solid #d8dee4;"
+    },
+    "dropdown": {
+        "type": "select",
+        "class": "",
+        "style": "padding: 3px 5px; border-radius: 2px; border: 1px solid #d8dee4;"
+    },
+    "button": {
+        "type": "button",
+        "class": "",
+        "id": "",
+        "style": "background-color: #00baff; border: none; border-radius: 4px; padding: 10px 20px; color: #ffffff; margin-top: 20px; cursor: pointer;"
+    },
+    "label": {
+        "type": "label",
+        "class": "",
+        "style": "padding-left: 5px; display: inline-block;"
+    },
+    "loader": {
+        "type": "img",
+        "src": "//www.newsletter2go.com/images/loader.svg",
+        "class": "",
+        "style": "margin: auto; display:block;"
+    },
+    "message": {
+        "type": "h2",
+        "class": "",
+        "id": "",
+        "style": "text-align: center;"
+    }
+}

--- a/src/newsletter2go.php
+++ b/src/newsletter2go.php
@@ -4,7 +4,7 @@
   Plugin Name: Newsletter2Go
   Plugin URI: https://www.newsletter2go.co.uk/features/wordpress-newsletter-plugin/
   Description: Adds email marketing functionality to your E-commerce platform. Easily synchronize your contacts and send product newsletters
-  Version: 4.0.13
+  Version: 4.0.14
   Author: Newsletter2Go
   Author URI: https://www.newsletter2go.de/
  */

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -2,9 +2,9 @@
 Contributors: newsletter2go
 Donate link: http://www.newsletter2go.com
 Tags: email, email marketing, emailing, email marketing software, newsletter, newsletter software, newsletter plugin, newsletter widget, content, content transfer, subscribers
-Requires PHP: 5.2.4
-Tested up to: 5.9
-Stable tag: 4.0.13
+Requires PHP: 7.1
+Tested up to: 6.5
+Stable tag: 4.0.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -89,6 +89,10 @@ Wählen Sie in Ihrem Backend das Widget Newsletter2Go aus. Ist das Plugin instal
 4. Passen Sie Ihre Anmeldeformulare für den Newsletter Ihrem Design an.
 
 == Changelog ==
+
+= 4.0.14 =
+* update compatibility version
+* fix vulnerability in resetStyles
 
 = 4.0.13 =
 * update compatibility version


### PR DESCRIPTION
Now in `resetStyles()` the default form styling is picked up from `newsletter2go_default.json` file and not `$_POST`

This fixes security vulnerability

Tested with Wordpress 6.5.2 and PHP 8.3